### PR TITLE
fix: add display inline block and margin auto

### DIFF
--- a/index.css
+++ b/index.css
@@ -905,6 +905,11 @@ transform: scale(1.1);
 		visibility: hidden;
 	} */
 
+	#carouselSocials div {
+		display: inline-block !important;
+		margin: auto;
+	}
+
 	.content {
 		min-height: 23rem;
 		height: auto;


### PR DESCRIPTION
## Description

- Added display inline-block and margin-auto to increase the size of the carousel socials icons when screen is less than 450px

## Screenshot

![image](https://github.com/user-attachments/assets/362797ff-5015-4451-9d64-f1f98faf2301)
