### PR TITLE
fix: remove carousel picture fixed height and width

### DIFF
--- a/index.css
+++ b/index.css
@@ -827,12 +827,6 @@ transform: scale(1.1);
 		font-size: 55%
 	}
 
-	#carouselPicture {
-		height: 20rem;
-		width: 20rem;
-		position: relative;
-	}
-
 	#fullName > i {
 		font-size: 2.7rem;
 	}


### PR DESCRIPTION
## Description

- Fixed overlap between carousel picture and about me header for screens with low height.

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/324dfd6d-2ec1-4642-be9f-29777c97bc2d)

After:
![image](https://github.com/user-attachments/assets/1da3ef20-d525-4239-bf74-191f9e7e74c2)
