### PR TITLE
Fix/full name and profession animation at 1512 px screen width

### DIFF
--- a/index.css
+++ b/index.css
@@ -91,7 +91,6 @@ html.no-scroll {
 }
 
 .landing-col {
-  max-width: 100vw;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -113,7 +112,7 @@ html.no-scroll {
   align-items: flex-end;
 }
 
-  #full-name > i,
+#full-name > i,
 #profession > i {
   display: inline-flex;
   font-style: normal;

--- a/index.css
+++ b/index.css
@@ -788,6 +788,11 @@ html.no-scroll {
 
 /* navbar hover and underline end */
 
+#landing-spacer {
+  height: 90%;
+  width: 100px;
+}
+
 @media (width <= 450px) {
   #landing {
     min-height: 100vh + 1px;
@@ -998,5 +1003,17 @@ html.no-scroll {
   .project-details .detail .col-12 i {
     text-align: left;
     font-size: 1.3rem;
+  }
+}
+
+@media (max-width: 1199px) {
+  #landing-spacer {
+    display: none;
+  }
+}
+
+@media (min-width: 1300px) {
+  #landing-spacer {
+    display: none;
   }
 }

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
       </div>
       <!-- End of Nav Bar -->
       <div id="landing-text">
+        <div id="landing-spacer"></div>
         <div class="container-fluid">
           <div class="row no-gutters">
             <div class="col-12 col-xl-6 landing-col">

--- a/index.html
+++ b/index.html
@@ -88,11 +88,11 @@
               <div id="profession" class="col-12">
                 <i data-final="F">F</i>
                 <i data-final="u">u</i>
-                <i data-final="l" class="letter-adjustment">l</i>
-                <i data-final="l" class="letter-adjustment">l</i>
+                <i data-final="l">l</i>
+                <i data-final="l">l</i>
                 <i data-final="-">-</i>
                 <i data-final="S">S</i>
-                <i data-final="t" class="letter-adjustment">t</i>
+                <i data-final="t">t</i>
                 <i data-final="a">a</i>
                 <i data-final="c">c</i>
                 <i data-final="k">k</i>
@@ -105,7 +105,7 @@
                 <i data-final="e">e</i>
                 <i data-final="v">v</i>
                 <i data-final="e">e</i>
-                <i data-final="l" class="letter-adjustment">l</i>
+                <i data-final="l">l</i>
                 <i data-final="o">o</i>
                 <i data-final="p">p</i>
                 <i data-final="e">e</i>


### PR DESCRIPTION
## Description

- Added '#landing-spacer' div to improve overflow of full-name and profession on the left side of the screen.
- Removed width properties of '.landing-col' to improve the overflow between the two '.landing-col'.